### PR TITLE
livedisplay: sysfs: chown on init

### DIFF
--- a/livedisplay/aidl/sysfs/vendor.lineage.livedisplay-service.sysfs.rc
+++ b/livedisplay/aidl/sysfs/vendor.lineage.livedisplay-service.sysfs.rc
@@ -1,4 +1,4 @@
-on early-boot
+on init
     # LiveDisplay sysfs
     chown system system /sys/devices/platform/soc/soc:qcom,dsi-display-primary/cabc
     chown system system /sys/devices/platform/soc/soc:qcom,dsi-display-primary/dc


### PR DESCRIPTION
early-boot is too late for some devices

Change-Id: I38d6d0e466fd57c27003bfc2142fd846ad1971b2